### PR TITLE
Change MRTK package source

### DIFF
--- a/Unity/Refract/Packages/manifest.json
+++ b/Unity/Refract/Packages/manifest.json
@@ -1,8 +1,18 @@
 {
+  "scopedRegistries": [
+    {
+      "name": "Microsoft Mixed Reality",
+      "url": "https://pkgs.dev.azure.com/aipmr/MixedReality-Unity-Packages/_packaging/Unity-packages/npm/registry/",
+      "scopes": [
+        "com.microsoft.mixedreality",
+        "com.microsoft.spatialaudio"
+      ]
+    }
+  ],
   "dependencies": {
     "com.hecomi.udesktopduplication": "https://github.com/hecomi/uDesktopDuplication.git#upm",
-    "com.microsoft.mixedreality.toolkit.foundation": "file:MixedReality/com.microsoft.mixedreality.toolkit.foundation-2.7.2.tgz",
-    "com.microsoft.mixedreality.toolkit.standardassets": "file:MixedReality/com.microsoft.mixedreality.toolkit.standardassets-2.7.2.tgz",
+    "com.microsoft.mixedreality.toolkit.foundation":"2.7.2",
+    "com.microsoft.mixedreality.toolkit.standardassets":"2.7.2",
     "com.unity.collab-proxy": "1.11.2",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.12",

--- a/Unity/Refract/ProjectSettings/PackageManagerSettings.asset
+++ b/Unity/Refract/ProjectSettings/PackageManagerSettings.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   m_EnablePackageDependencies: 0
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
-  oneTimeWarningShown: 0
+  oneTimeWarningShown: 1
   m_Registries:
   - m_Id: main
     m_Name: 
@@ -24,20 +24,31 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
+  - m_Id: scoped:Microsoft Mixed Reality
+    m_Name: Microsoft Mixed Reality
+    m_Url: https://pkgs.dev.azure.com/aipmr/MixedReality-Unity-Packages/_packaging/Unity-packages/npm/registry
+    m_Scopes:
+    - com.microsoft.mixedreality
+    - com.microsoft.spatialaudio
+    m_IsDefault: 0
+    m_Capabilities: 0
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
-      m_Id: 
-      m_Name: 
-      m_Url: 
-      m_Scopes: []
+      m_Id: scoped:Microsoft Mixed Reality
+      m_Name: Microsoft Mixed Reality
+      m_Url: https://pkgs.dev.azure.com/aipmr/MixedReality-Unity-Packages/_packaging/Unity-packages/npm/registry
+      m_Scopes:
+      - com.microsoft.mixedreality
+      - com.microsoft.spatialaudio
       m_IsDefault: 0
       m_Capabilities: 0
-    m_Modified: 0
-    m_Name: 
-    m_Url: 
+    m_Modified: 1
+    m_Name: Microsoft Mixed Reality
+    m_Url: https://pkgs.dev.azure.com/aipmr/MixedReality-Unity-Packages/_packaging/Unity-packages/npm/registry
     m_Scopes:
-    - 
-    m_SelectedScopeIndex: 0
+    - com.microsoft.mixedreality
+    - com.microsoft.spatialaudio
+    m_SelectedScopeIndex: 1


### PR DESCRIPTION
In the original configuration, the MRTK package was installed from local disk.
Installing from the official Microsoft registry makes it easier to maintain and improves the environment for other developers.